### PR TITLE
Dwarsprofielen

### DIFF
--- a/WBD_tools/process_profiles.py
+++ b/WBD_tools/process_profiles.py
@@ -77,6 +77,8 @@ class PROCESS_PROFILES:
             else:
                 raw_data.to_file(os.path.join(path_export,'profielpunt.gpkg'), driver='GPKG')
 
+            # remove hydroobjects for which process_profiles.run() could not assign a leggerprofile from a nearby hydroobject (happens if nearby hydroobject is not split at junction with current hydroobject)
+            raw_data.dropna(subset=['Z',], inplace=True)
 
             for code in network_data['code'].values:
                 # remove hydroobjects without leggerprofiles

--- a/WBD_tools/process_profiles.py
+++ b/WBD_tools/process_profiles.py
@@ -31,49 +31,40 @@ class PROCESS_PROFILES:
             network_data = gpd.read_file(os.path.join(path_shape,"hydroobject.gpkg"))
             
             for index,row in raw_data.iterrows():
-                
-                if 'OVK07859' not in row['profiellijnid']:
-                    if row['Z']<-6:
-                        if row['Z']<-900:
 
-                            network_id=row['profiellijnid'][0:8]
-                            
-                            buffer_drain=network_data[network_data['code']==network_id]['geometry'].buffer(30,cap_style ='square').unary_union
-                            nearby_points=raw_data.intersects(buffer_drain)
+                no_z = np.isnan(row['Z'])
+                if row['Z']<-6 or no_z:
+                    if row['Z']<-900 or no_z:
 
-                            try:
-                                idx=raw_data
-                                update_value=min(raw_data.loc[nearby_points,'Z'][raw_data['Z']>-15])
-                                
-                                if raw_data.loc[index,'codevolgnummer']>1 and raw_data.loc[index,'codevolgnummer']<4:
-                                    raw_data.loc[index,'geometry']=Point(raw_data.loc[index,'geometry'].x,raw_data.loc[index,'geometry'].y,update_value)
-                                    raw_data.loc[index,'Z']=update_value
-                                else:
-                                    raw_data.loc[index,'geometry']=Point(raw_data.loc[index,'geometry'].x,raw_data.loc[index,'geometry'].y,update_value+5)
-                                    raw_data.loc[index,'Z']=update_value+5
-                                raw_data.loc[index,'commentz']= 'Bodemhoogte aangevuld met data in de buurt'
-                            except:
-                                
-                                raw_data.loc[index,'commentz']='geen waarde gevonden'
+                        network_id=row['profiellijnid'][0:8]
+                        
+                        buffer_drain=network_data[network_data['code']==network_id]['geometry'].buffer(30,cap_style ='square').unary_union
+                        nearby_points=raw_data.intersects(buffer_drain) # profielpunten binnen 30 meter van het het huidige profielpunt dat een hoogte < 900m heeft 
 
-                        elif row['Z']<-100:
-                            raw_data.loc[index,'geometry']=Point(raw_data.loc[index,'geometry'].x,raw_data.loc[index,'geometry'].y,raw_data.loc[index,'Z']*0.01)
-                            raw_data.loc[index,'Z']=raw_data.loc[index,'Z']*0.01
+                        try:
+                            update_value=min(raw_data.loc[nearby_points,'Z'][raw_data['Z']>-15])
                             
-                            raw_data.loc[index,'commentz']= 'Decimaal punt ontbreekt in data dit gecorrigeerd (factor 100 lager)'  
-                        else:
-                            raw_data.loc[index,'geometry']=Point(raw_data.loc[index,'geometry'].x,raw_data.loc[index,'geometry'].y,raw_data.loc[index,'Z']*0.1)
-                            raw_data.loc[index,'Z']=raw_data.loc[index,'Z']*0.1
+                            if raw_data.loc[index,'codevolgnummer']>1 and raw_data.loc[index,'codevolgnummer']<4: # als het de waterbodem betreft... 
+                                raw_data.loc[index,'geometry']=Point(raw_data.loc[index,'geometry'].x,raw_data.loc[index,'geometry'].y,update_value)
+                                raw_data.loc[index,'Z']=update_value
+                            else: # als het het talud/insteek betreft...
+                                raw_data.loc[index,'geometry']=Point(raw_data.loc[index,'geometry'].x,raw_data.loc[index,'geometry'].y,update_value+5)
+                                raw_data.loc[index,'Z']=update_value+5
+                            raw_data.loc[index,'commentz']= 'Bodemhoogte aangevuld met data in de buurt'
+                        except:
                             
-                            raw_data.loc[index,'commentz']= 'Decimaal punt ontbreekt in data dit gecorrigeerd (factor 10 lager)' 
-                else:
-                    if raw_data.loc[index,'codevolgnummer']>1 and raw_data.loc[index,'codevolgnummer']<4:
-                        raw_data.loc[index,'geometry']=Point(raw_data.loc[index,'geometry'].x,raw_data.loc[index,'geometry'].y,0)
-                        raw_data.loc[index,'Z']=0  
+                            raw_data.loc[index,'commentz']='geen waarde gevonden'
+
+                    elif row['Z']<-100:
+                        raw_data.loc[index,'geometry']=Point(raw_data.loc[index,'geometry'].x,raw_data.loc[index,'geometry'].y,raw_data.loc[index,'Z']*0.01)
+                        raw_data.loc[index,'Z']=raw_data.loc[index,'Z']*0.01
+                        
+                        raw_data.loc[index,'commentz']= 'Decimaal punt ontbreekt in data dit gecorrigeerd (factor 100 lager)'  
                     else:
-                        raw_data.loc[index,'geometry']=Point(raw_data.loc[index,'geometry'].x,raw_data.loc[index,'geometry'].y,5)
-                        raw_data.loc[index,'Z']=5 
-                    raw_data.loc[index,'commentz']='geen waarde gevonden aangevuld met stadaardwaarde'     
+                        raw_data.loc[index,'geometry']=Point(raw_data.loc[index,'geometry'].x,raw_data.loc[index,'geometry'].y,raw_data.loc[index,'Z']*0.1)
+                        raw_data.loc[index,'Z']=raw_data.loc[index,'Z']*0.1
+                        
+                        raw_data.loc[index,'commentz']= 'Decimaal punt ontbreekt in data dit gecorrigeerd (factor 10 lager)' 
 
 
             path_export = os.path.join(self.root_dir, "Profiles",dijkring)
@@ -86,13 +77,15 @@ class PROCESS_PROFILES:
             else:
                 raw_data.to_file(os.path.join(path_export,'profielpunt.gpkg'), driver='GPKG')
 
-            # remove hydroobjects without leggerprofiles
-            for code in network_data['code'].values:
-                
-                if sum(raw_data['profiellijnid']==code)<4:
 
+            for code in network_data['code'].values:
+                # remove hydroobjects without leggerprofiles
+                if sum(raw_data['profiellijnid']==code)<4:
                     idx=network_data[network_data['code']==code].index
                     network_data.drop(idx,inplace=True)
+                # indicatie in hydroobjects output which hydroobjects have corrected leggerprofiles
+                elif raw_data.loc[raw_data['profiellijnid']==code, 'commentz'].any():
+                    network_data.loc[network_data['code']==code, 'commentprofiel'] = 'leggerprofiel aangevuld of gecorrigeerd'
 
             path_export = os.path.join(self.root_dir, "Network",dijkring)
             if not os.path.exists(path_export):

--- a/WBD_tools/process_profiles.py
+++ b/WBD_tools/process_profiles.py
@@ -66,17 +66,6 @@ class PROCESS_PROFILES:
                         
                         raw_data.loc[index,'commentz']= 'Decimaal punt ontbreekt in data dit gecorrigeerd (factor 10 lager)' 
 
-
-            path_export = os.path.join(self.root_dir, "Profiles",dijkring)
-            if not os.path.exists(path_export):
-                os.makedirs(path_export)
-
-            raw_data.set_crs(epsg=28992, inplace=True, allow_override=True)
-            if len(self.dijkringen) > 1:
-                raw_data.to_file(os.path.join(path_export,'profielpunt_' + dijkring + '.gpkg'), driver='GPKG')
-            else:
-                raw_data.to_file(os.path.join(path_export,'profielpunt.gpkg'), driver='GPKG')
-
             # remove hydroobjects for which process_profiles.run() could not assign a leggerprofile from a nearby hydroobject (happens if nearby hydroobject is not split at junction with current hydroobject)
             raw_data.dropna(subset=['Z',], inplace=True)
 
@@ -88,6 +77,16 @@ class PROCESS_PROFILES:
                 # indicatie in hydroobjects output which hydroobjects have corrected leggerprofiles
                 elif raw_data.loc[raw_data['profiellijnid']==code, 'commentz'].any():
                     network_data.loc[network_data['code']==code, 'commentprofiel'] = 'leggerprofiel aangevuld of gecorrigeerd'
+
+            path_export = os.path.join(self.root_dir, "Profiles",dijkring)
+            if not os.path.exists(path_export):
+                os.makedirs(path_export)
+
+            raw_data.set_crs(epsg=28992, inplace=True, allow_override=True)
+            if len(self.dijkringen) > 1:
+                raw_data.to_file(os.path.join(path_export,'profielpunt_' + dijkring + '.gpkg'), driver='GPKG')
+            else:
+                raw_data.to_file(os.path.join(path_export,'profielpunt.gpkg'), driver='GPKG')
 
             path_export = os.path.join(self.root_dir, "Network",dijkring)
             if not os.path.exists(path_export):


### PR DESCRIPTION
Dwarsprofielen zonder Z-waarden hebben nu Z-waarden.
Bovendien worden deze Z-correcties nu in de uitvoer voor hydroobjecten (.gpkg) gelogd, omdat dit van belang is voor team Gegevens om het beheerregister te kunnen verbeteren.