### PR TITLE
RUN_DIMR_BAT in .env, gelezen met fnames

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,11 @@
+[mypy]
+plugins = pydantic.mypy, numpy.typing.mypy_plugin
+
+warn_unused_configs = True
+warn_redundant_casts = True
+warn_unused_ignores = True
+strict_equality = True
+strict_concatenate = True
+disallow_subclassing_any = True
+disallow_untyped_decorators = True
+disallow_any_generics = True

--- a/scripts/aa_of_weerijs/2_D-HyDAMO_driver.py
+++ b/scripts/aa_of_weerijs/2_D-HyDAMO_driver.py
@@ -33,12 +33,6 @@ from wbd_tools.fnames import get_fnames
 
 warnings.simplefilter(action="ignore", category=FutureWarning)
 
-
-# In[2]:
-
-os.getcwd()
-
-
 # In[3]:
 
 
@@ -1640,9 +1634,7 @@ if RR:
 
 dimr = DIMRWriter(
     output_path=output_path,
-    dimr_path=str(
-        r"C:\Program Files\Deltares\D-HYDRO Suite 2024.03 1D2D\plugins\DeltaShell.Dimr\kernels\x64\bin\run_dimr.bat"
-    ),
+    dimr_path=fnames["run_dimr_bat"].as_posix(),
 )
 
 

--- a/wbd_tools/fnames.py
+++ b/wbd_tools/fnames.py
@@ -41,21 +41,26 @@ def load_env_to_dict(env_file: Path | None = None):
 
 
 # %%
-def get_fnames(AFWATERINGSEENHEDEN_DIR: Path | None = None, MODELLEN_DIR: Path | None = None) -> dict[Path]:
+def get_fnames(
+    AFWATERINGSEENHEDEN_DIR: Path | None = None, MODELLEN_DIR: Path | None = None, RUN_DIMR_BAT: Path | None = None
+) -> dict[Path]:
     """Get all fnames from"""
     fnames = {k.lower(): v for k, v in locals().items()}
-
-    env = None
+    print(fnames)
+    env = load_env_to_dict()
     for variable, value in fnames.items():
         # if not specified we read it from .env
         if value is None:
-            # load env
-            if env is None:
-                env = load_env_to_dict()
             # raise ValueError if local is not in env
             if variable.upper() not in env.keys():
-                raise ValueError(f"{variable.upper()} not specified as input nor in {find_env_file()}")
-            fnames[variable] = Path(env[variable.upper()])
+                if variable == "run_dimr_bat":
+                    fnames[variable] = Path(
+                        r"C:\Program Files\Deltares\D-HYDRO Suite 2024.03 1D2D\plugins\DeltaShell.Dimr\kernels\x64\bin\run_dimr.bat"
+                    )
+                else:
+                    raise ValueError(f"{variable.upper()} not specified as input nor in {find_env_file()}")
+            else:
+                fnames[variable] = Path(env[variable.upper()])
         else:
             fnames[variable] = Path(value)
 


### PR DESCRIPTION
Sluit taak: [13060](https://dev.azure.com/BrabantseDelta/Modellering%20Hydrologie/_workitems/edit/13060)

Verbeteringen
- `RUN_DIMR_BAT` in .env file
- get_fnames() heeft de mogelijkheid een RUN_DIMR_BAT variabele op te geven. Wordt deze niet gespecificeerd, dan wordt deze ingelezen uit de .env file. Zit deze ook daar niet in, dan default hij naar `C:\Program Files\Deltares\D-HYDRO Suite 2024.03 1D2D\plugins\DeltaShell.Dimr\kernels\x64\bin\run_dimr.bat`